### PR TITLE
FlockLab Interface Library we used for our multi-hop experiments

### DIFF
--- a/apps/flocklab-interface/Makefile.flocklab-interface
+++ b/apps/flocklab-interface/Makefile.flocklab-interface
@@ -1,0 +1,1 @@
+flocklab-interface_src = flocklab-interface.c

--- a/apps/flocklab-interface/flocklab-interface.c
+++ b/apps/flocklab-interface/flocklab-interface.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2014, Institute for Pervasive Computing, ETH Zurich.
+ * All rights reserved.
+ *
+ * Author: Andreas Dröscher <contiki@anticat.ch>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#include "flocklab-interface.h"
+
+void flocklab_init() {
+  /*
+   * Configure FlockLab output pins
+   */
+  GPIO_SOFTWARE_CONTROL(LED_PORT, LED1_MASK); //LED1
+  GPIO_SET_OUTPUT(LED_PORT, LED1_MASK);
+  GPIO_SOFTWARE_CONTROL(LED_PORT, LED2_MASK); //LED2
+  GPIO_SET_OUTPUT(LED_PORT, LED2_MASK);
+  GPIO_SOFTWARE_CONTROL(LED_PORT, LED3_MASK); //LED3
+  GPIO_SET_OUTPUT(LED_PORT, LED3_MASK);
+  GPIO_SOFTWARE_CONTROL(INT_PORT, INT1_MASK); //INT1
+  GPIO_SET_OUTPUT(INT_PORT, INT1_MASK);
+  GPIO_SOFTWARE_CONTROL(INT_PORT, INT2_MASK); //INT2
+  GPIO_SET_OUTPUT(INT_PORT, INT2_MASK);
+
+  /*
+   * Configure FlockLab input pins
+   */
+  GPIO_SOFTWARE_CONTROL(SIG_PORT, SIG1_MASK);
+  GPIO_SET_INPUT(SIG_PORT, SIG1_MASK);
+  GPIO_SOFTWARE_CONTROL(SIG_PORT, SIG2_MASK);
+  GPIO_SET_INPUT(SIG_PORT, SIG2_MASK);
+}
+
+void flocklab_register_callback(gpio_callback_t f, uint8_t pin) {
+  gpio_register_callback(f, SIG_PORT_NUM, pin);
+  GPIO_DETECT_EDGE(SIG_PORT, GPIO_PIN_MASK(pin));
+  GPIO_TRIGGER_BOTH_EDGES(SIG_PORT, GPIO_PIN_MASK(pin));
+  GPIO_ENABLE_INTERRUPT(SIG_PORT, GPIO_PIN_MASK(pin));
+  GPIO_ENABLE_POWER_UP_INTERRUPT(SIG_PORT_NUM, GPIO_PIN_MASK(pin));
+  GPIO_POWER_UP_ON_RISING(SIG_PORT_NUM, GPIO_PIN_MASK(pin));
+  GPIO_POWER_UP_ON_FALLING(SIG_PORT_NUM, GPIO_PIN_MASK(pin));
+  nvic_interrupt_enable(SIG_PORT_NVIC);
+}

--- a/apps/flocklab-interface/flocklab-interface.h
+++ b/apps/flocklab-interface/flocklab-interface.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2014, Institute for Pervasive Computing, ETH Zurich.
+ * All rights reserved.
+ *
+ * Author: Andreas Dröscher <contiki@anticat.ch>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#ifndef FLOCKLAB_H_
+#define FLOCKLAB_H_
+
+//GPIO Driver Include
+#include <gpio.h>
+
+//NVIC Driver Include
+#include <nvic.h>
+
+/*
+ * FlockLab LED Outputs
+ */
+#define LED_PORT      GPIO_PORT_TO_BASE(GPIO_A_NUM)
+#define LED1_MASK     GPIO_PIN_MASK(2)
+#define LED2_MASK     GPIO_PIN_MASK(3)
+#define LED3_MASK     GPIO_PIN_MASK(4)
+
+/*
+ * FlockLab INT Outputs
+ */
+#define INT_PORT      GPIO_PORT_TO_BASE(GPIO_D_NUM)
+#define INT1_MASK     GPIO_PIN_MASK(0)
+#define INT2_MASK     GPIO_PIN_MASK(1)
+
+/*
+ * FlockLab SIGNAL Inputs
+ */
+#define SIG_PORT_NUM  GPIO_D_NUM
+#define SIG_PORT      GPIO_PORT_TO_BASE(SIG_PORT_NUM)
+#define SIG_PORT_NVIC NVIC_INT_GPIO_PORT_D
+#define SIG1_PIN      2
+#define SIG1_MASK     GPIO_PIN_MASK(SIG1_PIN)
+#define SIG2_PIN      3
+#define SIG2_MASK     GPIO_PIN_MASK(SIG2_PIN)
+
+/*
+ * Configures FlockLab I/O Pins
+ */
+void flocklab_init();
+
+/*
+ * Register Callback
+ */
+void flocklab_register_callback(gpio_callback_t f, uint8_t pin);
+
+#endif /* FLOCKLAB_H_ */

--- a/examples/openmote/flocklab-interface/Makefile
+++ b/examples/openmote/flocklab-interface/Makefile
@@ -1,0 +1,11 @@
+CONTIKI_PROJECT = flocklab
+
+DEFINES+=PROJECT_CONF_H=\"project-conf.h\"
+
+APPS += flocklab-interface flash-erase
+
+all: $(CONTIKI_PROJECT)
+
+CONTIKI = ../../..
+
+include $(CONTIKI)/Makefile.include

--- a/examples/openmote/flocklab-interface/README.md
+++ b/examples/openmote/flocklab-interface/README.md
@@ -1,0 +1,54 @@
+# FlockLab Interface Library
+The FlockLab Interface library simplifies the GPIO setup in Contiki OS. This directory contains a small example that outputs states on the LED1-LED3 and forwards signals on SIG1-SIG2 to INT1-INT2.
+
+To configure the GPIOs for correct operation call.
+```C
+void flocklab_init();
+```
+
+## Signal Output
+To Output Signals you can use the macros from gpio.h with the defines in flocklab-interface.h
+To toggle LED1 simply use:
+```C
+GPIO_SET_PIN(LED_PORT, LED1_MASK);
+GPIO_CLR_PIN(LED_PORT, LED1_MASK);
+```
+
+
+## Signal Input
+To trigger on actuations you can either poll the GPIO or register a callback. To read inputs you can use macros from gpio.h with the defines in flocklab-interface.h:
+
+```C
+if(GPIO_READ_PIN(SIG_PORT, SIG1_MASK)) {
+
+} else {
+
+}
+```
+
+Registering a callback works the usual way the flocklab\_register\_callback function registers the call back with gpio\_register\_callback and configures the NVIC for you. The callback is registered for both edges and to for all power levels including PM2.
+
+```C
+static void signal_cb(uint8_t port, uint8_t pin) {
+  //Handle Signal
+}
+
+PROCESS_THREAD(flocklab_idle_process, ev, data) {
+  PROCESS_BEGIN();
+  flocklab_init();
+  flocklab_register_callback(signal_cb, SIG1_PIN);
+  PROCESS_END();
+}
+```
+
+## Serial I/O
+Only UART0 of the OpenMote is connected to the serial interface of the FlockLab-Observer (the USB interface isn't). If you want to communicate to the target or trace the target using the serial interface, you have to explicitly select it in the FlockLab Test Configuration. 
+
+```XML
+<serialConf>
+  <obsIds>016 018 022 023 024</obsIds>
+  <baudrate>115200</baudrate>
+  <mode>ascii</mode>
+  <port>serial</port>
+</serialConf>
+```

--- a/examples/openmote/flocklab-interface/flocklab.c
+++ b/examples/openmote/flocklab-interface/flocklab.c
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2014, Institute for Pervasive Computing, ETH Zurich.
+ * All rights reserved.
+ *
+ * Author: Andreas Dröscher <contiki@anticat.ch>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#include <project-conf.h>
+
+//Contiki OS Includes
+#include <contiki.h>
+#include <contiki-net.h>
+#include <contiki-lib.h>
+#include <rtimer.h>
+#include <clock.h>
+
+//Additional Apps and Drivers
+#include <gpio.h>
+#include <leds.h>
+#include <flash-erase.h>
+#include <flocklab-interface.h>
+
+PROCESS(flocklab_idle_process, "FlockLab Idle Process");
+AUTOSTART_PROCESSES(&flocklab_idle_process, &flash_erase_process);
+
+/*
+ * Our rtimer fired event
+ */
+static process_event_t event_rtimer_fired;
+
+/*
+ * Struct of the sleep timer
+ */
+static struct rtimer sleep_timer;
+
+/*
+ * Current LED State
+ */
+static uint8_t led_state = 0;
+
+/*
+ * The Callback is called SIGx level changes (edge)
+ */
+static void signal_cb(uint8_t port, uint8_t pin) {
+  if(pin == SIG1_PIN) {
+    if(GPIO_READ_PIN(SIG_PORT, SIG1_MASK)) {
+      GPIO_SET_PIN(INT_PORT, INT1_MASK);
+    } else {
+      GPIO_CLR_PIN(INT_PORT, INT1_MASK);
+    }
+  }
+  
+  if(pin == SIG2_PIN) {
+    if(GPIO_READ_PIN(SIG_PORT, SIG2_MASK)) {
+      GPIO_SET_PIN(INT_PORT, INT2_MASK);
+    } else {
+      GPIO_CLR_PIN(INT_PORT, INT2_MASK);
+    }
+  }
+}
+
+/*
+ * The Callback is called when the timer expires
+ */
+void rt_callback(struct rtimer *t, void *ptr) {
+  process_post(&flocklab_idle_process, event_rtimer_fired, NULL);
+}
+
+PROCESS_THREAD(flocklab_idle_process, ev, data) {
+  PROCESS_BEGIN();
+
+  /*
+   * Disable Wireless
+   */
+  NETSTACK_MAC.off(0);
+  NETSTACK_RDC.off(0);
+  NETSTACK_RADIO.off();
+
+  /*
+   * Allocate EventID
+   */
+  event_rtimer_fired = process_alloc_event();
+
+  /*
+   * Configure FlockLab pins
+   */
+  flocklab_init();
+  flocklab_register_callback(signal_cb, SIG1_PIN);
+  flocklab_register_callback(signal_cb, SIG2_PIN);
+
+  /*
+   * Blink Internal and External LEDs
+   */
+  while(1) {
+    switch(led_state) {
+      case 0:
+        leds_on(LEDS_YELLOW);
+        leds_off(LEDS_ORANGE);
+        GPIO_SET_PIN(LED_PORT, LED1_MASK);
+        GPIO_CLR_PIN(LED_PORT, LED3_MASK);
+        break;
+      case 1:
+        leds_on(LEDS_GREEN);
+        leds_off(LEDS_YELLOW);
+        GPIO_SET_PIN(LED_PORT, LED2_MASK);
+        GPIO_CLR_PIN(LED_PORT, LED1_MASK);
+        break;
+      case 2:
+        leds_on(LEDS_ORANGE);
+        leds_off(LEDS_GREEN);
+        GPIO_SET_PIN(LED_PORT, LED3_MASK);
+        GPIO_CLR_PIN(LED_PORT, LED2_MASK);
+        break;
+    }
+    led_state = (led_state + 1) % 3;
+
+    /*
+     * Schedule the rtimer
+     */
+    rtimer_set(&sleep_timer, RTIMER_NOW() + RTIMER_SECOND*1, 1, (rtimer_callback_t)rt_callback, NULL);
+
+    /*
+     * Wait for the callback
+     */
+    PROCESS_WAIT_EVENT_UNTIL(ev == event_rtimer_fired);
+  }
+
+  PROCESS_END();
+}

--- a/examples/openmote/flocklab-interface/flocklab.xml
+++ b/examples/openmote/flocklab-interface/flocklab.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testConf xmlns="http://www.flocklab.ethz.ch" 
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+          xsi:schemaLocation="http://www.flocklab.ethz.ch xml/flocklab.xsd">
+
+  <!-- General configuration -->
+  <generalConf>
+    <name>FlockLab Test</name>
+    <description>
+      Tests all GPIOs
+    </description>
+    <scheduleAsap><durationSecs>60</durationSecs></scheduleAsap>
+    <emailResults>no</emailResults>
+  </generalConf>
+
+  <!-- Target configuration -->
+  <targetConf>
+    <obsIds>003 006 008 015 016 018 022 023 024 031</obsIds>
+    <voltage>3.3</voltage>
+    <embeddedImageId>flocklab</embeddedImageId>
+  </targetConf>
+
+  <serialConf>
+    <obsIds>003 006 008 015 016 018 022 023 024 031</obsIds>
+    <baudrate>115200</baudrate>
+    <mode>raw</mode>
+    <port>serial</port>
+  </serialConf>
+
+  <gpioTracingConf>
+    <obsIds>003 006 008 015 016 018 022 023 024 031</obsIds>
+    <pinConf>
+      <pin>INT1</pin>
+      <edge>both</edge>
+      <mode>continuous</mode>
+    </pinConf>
+    <pinConf>
+      <pin>INT2</pin>
+      <edge>both</edge>
+      <mode>continuous</mode>
+    </pinConf>
+    <pinConf>
+      <pin>LED1</pin>
+      <edge>both</edge>
+      <mode>continuous</mode>
+    </pinConf>
+    <pinConf>
+      <pin>LED2</pin>
+      <edge>both</edge>
+      <mode>continuous</mode>
+    </pinConf>
+    <pinConf>
+      <pin>LED3</pin>
+      <edge>both</edge>
+      <mode>continuous</mode>
+    </pinConf>
+  </gpioTracingConf>
+  
+  <gpioActuationConf>
+    <obsIds>003 006 008 015 016 018 022 023 024 031</obsIds>
+    <pinConf>
+      <pin>SIG1</pin>
+      <level>high</level>
+      <periodic>
+        <intervalMicrosecs>10000000</intervalMicrosecs>
+        <count>6</count>
+      </periodic>
+      <relativeTime>
+        <offsetSecs>0</offsetSecs>
+      </relativeTime>
+    </pinConf>
+    <pinConf>
+      <pin>SIG1</pin>
+      <level>low</level>
+      <periodic>
+        <intervalMicrosecs>10000000</intervalMicrosecs>
+        <count>6</count>
+      </periodic>
+      <relativeTime>
+        <offsetSecs>5</offsetSecs>
+      </relativeTime>
+    </pinConf>
+    <pinConf>
+      <pin>SIG2</pin>
+      <level>high</level>
+      <periodic>
+        <intervalMicrosecs>10000000</intervalMicrosecs>
+        <count>6</count>
+      </periodic>
+      <relativeTime>
+        <offsetSecs>5</offsetSecs>
+      </relativeTime>
+    </pinConf>
+    <pinConf>
+      <pin>SIG2</pin>
+      <level>low</level>
+      <periodic>
+        <intervalMicrosecs>10000000</intervalMicrosecs>
+        <count>6</count>
+      </periodic>
+      <relativeTime>
+        <offsetSecs>10</offsetSecs>
+      </relativeTime>
+    </pinConf>
+  </gpioActuationConf>
+  
+  <imageConf>
+    <embeddedImageId>flocklab</embeddedImageId>
+    <name>FlockLab Test</name>
+    <description></description>
+    <platform>openmote</platform>
+    <os>contiki</os>
+    <data>  <!-- base64 encoded elf --> </data>
+  </imageConf>
+</testConf>

--- a/examples/openmote/flocklab-interface/project-conf.h
+++ b/examples/openmote/flocklab-interface/project-conf.h
@@ -1,0 +1,10 @@
+#ifndef PROJECT_CONF_H_
+#define PROJECT_CONF_H_
+
+#define CC2538_CONF_QUIET                             1
+#define LPM_CONF_MAX_PM                               2
+
+#define FLASH_CCA_CONF_BOOTLDR_BACKDOOR_ACTIVE_HIGH   1
+#define FLASH_CCA_CONF_BOOTLDR_BACKDOOR_PORT_A_PIN    6
+
+#endif /* PROJECT_CONF_H_ */


### PR DESCRIPTION
I prepared the FlockLab Interface library for a public release. Its a wrapper that simplifies the interconnection with FlockLab. The pull request contains a example program, a short readme and an example configuration.
